### PR TITLE
Update Flask to 2.2.5 due to CVE-2023-30861.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.0.2
+Flask==2.2.5
 Flask-WTF==1.0.0
 Pillow==9.3.0


### PR DESCRIPTION
Closes #1.